### PR TITLE
Pressure plates send players through portals like sneaking

### DIFF
--- a/src/PlayerInteract.java
+++ b/src/PlayerInteract.java
@@ -1,0 +1,38 @@
+package net.simpvp.Portals;
+
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.player.PlayerInteractEvent;
+
+public class PlayerInteract implements Listener {
+
+	@EventHandler
+	public void onPlayerInteract(PlayerInteractEvent event) {
+		
+		if (event.getAction() == Action.PHYSICAL) {
+			
+			Player player = event.getPlayer();	
+			Block block = event.getClickedBlock();
+			
+			/* Other pressure plates seem to send multiple events when stepped on so only use wood and stone */
+			if (block.getType() != Material.STONE_PLATE && block.getType() != Material.WOOD_PLATE) {
+				return;
+			}
+			
+			if (PortalCheck.is_valid_portal(block)) {
+				Portals.instance.getLogger().info(player.getName() + " tried to use a portal by pressure plate at"
+						+ " " + block.getWorld().getName()
+						+ " " + block.getX()
+						+ " " + block.getY()
+						+ " " + block.getZ()
+						+ ".");
+				PortalUtils.teleport(player, block.getLocation());
+			}
+		}
+	}
+
+}

--- a/src/Portals.java
+++ b/src/Portals.java
@@ -26,9 +26,7 @@ public class Portals extends JavaPlugin {
 		getServer().getPluginManager().registerEvents(new PlayerDeath(), this);
 		getServer().getPluginManager().registerEvents(new PlayerToggleSneak(), this);
 		getServer().getPluginManager().registerEvents(new ChunkUnload(), this);
-		
-		/* Remove comment to enable minecart detection through portals */
-		/* getServer().getPluginManager().registerEvents(new BlockRedstone(), this); */
+		getServer().getPluginManager().registerEvents(new PlayerInteract(), this);
 
 		SQLite.connect();
 	}


### PR DESCRIPTION
-wood and stone pressure plates now auto send you through a portal when you activate them
-no longer get stuck sneaking after using a portal that sends you to a different world (seemed like that was the only time it happened)
-also lowered the cooldown between portal uses a bit