### PR TITLE
Crying obsidian portals

### DIFF
--- a/src/main/java/net/simpvp/Portals/BlockBreak.java
+++ b/src/main/java/net/simpvp/Portals/BlockBreak.java
@@ -18,7 +18,7 @@ public class BlockBreak implements Listener {
 
 	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled=true)
 	public void onBlockBreak(BlockBreakEvent event) {
-		if (event.getBlock().getType() != Material.OBSIDIAN)
+		if (!Portals.FRAMES.contains(event.getBlock().getType()))
 			return;
 
 		Block block = event.getBlock();

--- a/src/main/java/net/simpvp/Portals/BlockPlace.java
+++ b/src/main/java/net/simpvp/Portals/BlockPlace.java
@@ -18,7 +18,7 @@ public class BlockPlace implements Listener {
 	public void onBlockPlace(BlockPlaceEvent event) {
 		Material material = event.getBlock().getType();
 
-		if (material == Material.OBSIDIAN) {
+		if (Portals.FRAMES.contains(material)) {
 			check_obsi_placement(event);
 			return;
 		}
@@ -31,7 +31,7 @@ public class BlockPlace implements Listener {
 			return;
 
 		Block location = event.getBlock();
-		if (location.getRelative(BlockFace.DOWN).getType() != Material.OBSIDIAN)
+		if (!Portals.FRAMES.contains(location.getRelative(BlockFace.DOWN).getType()))
 			location = event.getBlock().getRelative(BlockFace.DOWN);
 
 		if ((location.getType() != Material.DIAMOND_BLOCK 

--- a/src/main/java/net/simpvp/Portals/PortalCheck.java
+++ b/src/main/java/net/simpvp/Portals/PortalCheck.java
@@ -34,7 +34,7 @@ public class PortalCheck {
 
 		for (int i = 0; i < path_eastwest.length; i++) {
 			block = block.getRelative(path_eastwest[i]);
-			if (block.getType() != Material.OBSIDIAN 
+			if (!Portals.FRAMES.contains(block.getType())
 					|| (broken != null &&block.getX() == broken.getX() 
 						&& block.getY() == broken.getY() 
 						&& block.getZ() == broken.getZ())) {
@@ -49,7 +49,7 @@ public class PortalCheck {
 		block = portal;
 		for (int i = 0; i < path_northsouth.length; i++) {
 			block = block.getRelative(path_northsouth[i]);
-			if (block.getType() != Material.OBSIDIAN 
+			if (!Portals.FRAMES.contains(block.getType())
 					|| (broken != null && block.getX() == broken.getX() 
 						&& block.getY() == broken.getY() 
 						&& block.getZ() == broken.getZ()))

--- a/src/main/java/net/simpvp/Portals/PortalUtils.java
+++ b/src/main/java/net/simpvp/Portals/PortalUtils.java
@@ -19,7 +19,6 @@ public class PortalUtils {
 	 * @param player player who is trying to teleport
 	 * @param portal block to check for portal location at
 	 */
-	@SuppressWarnings("deprecation")
 	public static void teleport(Player player, Location portal) {
 
 		/* Check if the player is trying to teleport again too fast */
@@ -57,11 +56,11 @@ public class PortalUtils {
 		Location fLoc = new Location(destination.getWorld(),
 				destination.getBlockX(), destination.getBlockY() - 1,
 				destination.getBlockZ());
-		player.sendBlockChange(fLoc, fLoc.getBlock().getType(), fLoc.getBlock().getData());
+		player.sendBlockChange(fLoc, fLoc.getBlock().getBlockData());
 		fLoc = new Location(destination.getWorld(),
 				destination.getBlockX(), destination.getBlockY(),
 				destination.getBlockZ());
-		player.sendBlockChange(fLoc, fLoc.getBlock().getType(), fLoc.getBlock().getData());
+		player.sendBlockChange(fLoc, fLoc.getBlock().getBlockData());
 
 		player.teleport(destination);	
 		teleportNearby(portal, destination, player);

--- a/src/main/java/net/simpvp/Portals/Portals.java
+++ b/src/main/java/net/simpvp/Portals/Portals.java
@@ -1,14 +1,22 @@
 package net.simpvp.Portals;
 
 import java.io.File;
+import java.util.Arrays;
 import java.util.UUID;
 import java.util.HashSet;
 
+import org.bukkit.Material;
 import org.bukkit.plugin.java.JavaPlugin;
 
 public class Portals extends JavaPlugin {
 
 	public static JavaPlugin instance;
+
+	/* Materials that a portal frame can use interchangeably */
+	public static final HashSet<Material> FRAMES = new HashSet<>(Arrays.asList(
+			Material.OBSIDIAN,
+			Material.CRYING_OBSIDIAN
+	));
 
 	public static HashSet<UUID> justTeleportedEntities = new HashSet<UUID>();
 


### PR DESCRIPTION
Let portals use crying obsidian interchangeably with normal obsidian, no functional use for this but it looks cool and someone requested it a while ago, I think 4Pilot.

Had to change the sendBlockChange thing in PortalUtils because the old way kept making the crying obsidian appear as invisible ghost blocks after using the portal, don't know why that was happening but that method is deprecated anyway so it should be ok.