### PR TITLE
fix entity suffocation

### DIFF
--- a/src/main/java/net/simpvp/Portals/PortalUtils.java
+++ b/src/main/java/net/simpvp/Portals/PortalUtils.java
@@ -175,6 +175,7 @@ public class PortalUtils {
 		 * The delay in previous versions seems to cause the duplication bug */
 		Collection<Entity> nearby = from.getWorld().getNearbyEntities(from, 2, 2, 2);
 		boolean somethingTeleported = false;
+		boolean differentWorld = !from.getWorld().getName().equals(destination.getWorld().getName());
 		for (Entity entity : nearby) {
 			if (!TELEPORTABLE_ENTITIES.contains(entity.getType())) {
 				continue;
@@ -186,6 +187,11 @@ public class PortalUtils {
 				}
 			}
 
+			/* Double teleports are required when changing worlds, otherwise non-player entities get stuck in the corner
+			 * of a block and suffocate (destination offsets do not fix this for some reason...) */
+			if (differentWorld) {
+				entity.teleport(destination);
+			}
 			entity.teleport(destination);
 			somethingTeleported = true;
 		}


### PR DESCRIPTION
Location offsets don't work when changing dimensions (probably a bug), and by default non-player entities are positioned in the corner of the destination block causing suffocation. 

This is easy to test with a non moving entity:
```/summon minecraft:skeleton ~ ~ ~ {NoAI:1b,Invulnerable:1}```