### PR TITLE
Add config file for teleportable entities

### DIFF
--- a/src/main/java/net/simpvp/Portals/Portals.java
+++ b/src/main/java/net/simpvp/Portals/Portals.java
@@ -38,6 +38,7 @@ public class Portals extends JavaPlugin {
 		getServer().getPluginManager().registerEvents(new PlayerInteract(), this);
 
 		SQLite.connect();
+		PortalUtils.loadTeleportable();
 	}
 
 	public void onDisable() {


### PR DESCRIPTION
Currently every update we have to go into PortalUtils and add the new entities manually. Changed this to a config file, also shows anything disabled for cut & paste ease.

Old `TELEPORTABLE_ENTITIES`  converted to new `plugins/Portals/config.yml`:
[config.yml.txt](https://github.com/user-attachments/files/17528582/config.yml.txt) 
(txt since github doesn't allow uploading yml for some reason)
